### PR TITLE
feat: implement MCP session discovery (Issue #2)

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,0 +1,69 @@
+import { execSync } from 'child_process'
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+
+describe('CLI sessions command', () => {
+  let tempDir: string
+  const cliPath = path.join(__dirname, '..', 'dist', 'cli.js')
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-term-cli-test-'))
+  })
+
+  afterEach(() => {
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('should output empty list when no sessions exist', () => {
+    const output = execSync(`node ${cliPath} sessions --lock-dir="${tempDir}"`, {
+      encoding: 'utf8',
+      env: { ...process.env, NODE_ENV: 'test' },
+    })
+
+    expect(output.trim()).toBe('No Claude Code sessions found.')
+  })
+
+  it('should output session list when sessions exist', () => {
+    const session1 = { port: 8080, context: 'project1', project: '/path/to/project1' }
+    const session2 = { port: 8081, context: 'project2', project: '/path/to/project2' }
+
+    fs.writeFileSync(path.join(tempDir, 'claude-session1.lock'), JSON.stringify(session1))
+    fs.writeFileSync(path.join(tempDir, 'claude-session2.lock'), JSON.stringify(session2))
+
+    const output = execSync(`node ${cliPath} sessions --lock-dir="${tempDir}"`, {
+      encoding: 'utf8',
+      env: { ...process.env, NODE_ENV: 'test' },
+    })
+
+    expect(output).toContain('Found 2 Claude Code sessions:')
+    expect(output).toContain('Port: 8080, Context: project1, Project: /path/to/project1')
+    expect(output).toContain('Port: 8081, Context: project2, Project: /path/to/project2')
+  })
+
+  it('should ignore invalid lock files', () => {
+    const validSession = { port: 8080, context: 'valid', project: '/valid/project' }
+
+    fs.writeFileSync(path.join(tempDir, 'claude-valid.lock'), JSON.stringify(validSession))
+    fs.writeFileSync(path.join(tempDir, 'claude-invalid.lock'), 'invalid json')
+
+    const output = execSync(`node ${cliPath} sessions --lock-dir="${tempDir}"`, {
+      encoding: 'utf8',
+      env: { ...process.env, NODE_ENV: 'test' },
+    })
+
+    expect(output).toContain('Found 1 Claude Code session:')
+    expect(output).toContain('Port: 8080, Context: valid, Project: /valid/project')
+  })
+
+  it('should use /tmp as default directory when no --lock-dir provided', () => {
+    const output = execSync(`node ${cliPath} sessions`, {
+      encoding: 'utf8',
+      env: { ...process.env, NODE_ENV: 'test' },
+    })
+
+    expect(output).toMatch(/(No Claude Code sessions found\.|Found \d+ Claude Code session)/)
+  })
+})

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+import { Command } from 'commander'
+import { listSessions } from './session-discovery.js'
+import { fileURLToPath } from 'url'
+
+const program = new Command()
+
+program
+  .name('claude-term')
+  .description('CLI tool for connecting to Claude Code MCP servers')
+  .version('0.0.1')
+
+program
+  .command('sessions')
+  .description('List available Claude Code sessions')
+  .option('--lock-dir <path>', 'Directory to scan for lock files', '/tmp')
+  .action((options: { lockDir: string }) => {
+    const sessions = listSessions(options.lockDir)
+
+    if (sessions.length === 0) {
+      console.log('No Claude Code sessions found.')
+    } else {
+      const sessionText = sessions.length === 1 ? 'session' : 'sessions'
+      console.log(`Found ${sessions.length} Claude Code ${sessionText}:`)
+
+      sessions.forEach((session) => {
+        console.log(
+          `Port: ${session.port}, Context: ${session.context}, Project: ${session.project}`,
+        )
+      })
+    }
+  })
+
+const isMainModule = process.argv[1] === fileURLToPath(import.meta.url)
+if (isMainModule) {
+  program.parse()
+}
+
+export { program }

--- a/src/session-discovery.test.ts
+++ b/src/session-discovery.test.ts
@@ -1,0 +1,140 @@
+import { SessionInfo, listSessions, parseLockFile } from './session-discovery'
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+
+describe('Session Discovery', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-term-test-'))
+  })
+
+  afterEach(() => {
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  describe('SessionInfo type', () => {
+    it('should have required properties', () => {
+      const sessionInfo: SessionInfo = {
+        port: 8080,
+        context: 'test-context',
+        project: 'test-project',
+      }
+
+      expect(sessionInfo.port).toBe(8080)
+      expect(sessionInfo.context).toBe('test-context')
+      expect(sessionInfo.project).toBe('test-project')
+    })
+
+    it('should handle numeric port values', () => {
+      const sessionInfo: SessionInfo = {
+        port: 3000,
+        context: 'another-context',
+        project: 'another-project',
+      }
+
+      expect(typeof sessionInfo.port).toBe('number')
+      expect(sessionInfo.port).toBe(3000)
+    })
+  })
+
+  describe('parseLockFile', () => {
+    it('should parse a valid lock file', () => {
+      const lockContent = JSON.stringify({
+        port: 8080,
+        context: 'my-context',
+        project: 'my-project',
+      })
+
+      const lockPath = path.join(tempDir, 'claude-test.lock')
+      fs.writeFileSync(lockPath, lockContent)
+
+      const result = parseLockFile(lockPath)
+
+      expect(result).toEqual({
+        port: 8080,
+        context: 'my-context',
+        project: 'my-project',
+      })
+    })
+
+    it('should return null for malformed JSON', () => {
+      const lockPath = path.join(tempDir, 'claude-invalid.lock')
+      fs.writeFileSync(lockPath, 'invalid json content')
+
+      const result = parseLockFile(lockPath)
+
+      expect(result).toBeNull()
+    })
+
+    it('should return null for non-existent file', () => {
+      const lockPath = path.join(tempDir, 'non-existent.lock')
+
+      const result = parseLockFile(lockPath)
+
+      expect(result).toBeNull()
+    })
+
+    it('should return null for lock file missing required fields', () => {
+      const lockContent = JSON.stringify({
+        port: 8080,
+        context: 'my-context',
+        // missing project field
+      })
+
+      const lockPath = path.join(tempDir, 'claude-incomplete.lock')
+      fs.writeFileSync(lockPath, lockContent)
+
+      const result = parseLockFile(lockPath)
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('listSessions', () => {
+    it('should return empty array when no lock files exist', () => {
+      const result = listSessions(tempDir)
+
+      expect(result).toEqual([])
+    })
+
+    it('should return sessions from valid lock files', () => {
+      const session1 = { port: 8080, context: 'context1', project: 'project1' }
+      const session2 = { port: 8081, context: 'context2', project: 'project2' }
+
+      fs.writeFileSync(path.join(tempDir, 'claude-session1.lock'), JSON.stringify(session1))
+      fs.writeFileSync(path.join(tempDir, 'claude-session2.lock'), JSON.stringify(session2))
+
+      const result = listSessions(tempDir)
+
+      expect(result).toHaveLength(2)
+      expect(result).toContainEqual(session1)
+      expect(result).toContainEqual(session2)
+    })
+
+    it('should ignore invalid lock files but return valid ones', () => {
+      const validSession = { port: 8080, context: 'valid', project: 'valid-project' }
+
+      fs.writeFileSync(path.join(tempDir, 'claude-valid.lock'), JSON.stringify(validSession))
+      fs.writeFileSync(path.join(tempDir, 'claude-invalid.lock'), 'invalid json')
+      fs.writeFileSync(
+        path.join(tempDir, 'non-claude-file.lock'),
+        JSON.stringify({ port: 9999, context: 'other', project: 'other' }),
+      )
+
+      const result = listSessions(tempDir)
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).toEqual(validSession)
+    })
+
+    it('should use /tmp as default directory', () => {
+      const result = listSessions()
+
+      expect(Array.isArray(result)).toBe(true)
+    })
+  })
+})

--- a/src/session-discovery.ts
+++ b/src/session-discovery.ts
@@ -1,0 +1,68 @@
+import fs from 'fs'
+import path from 'path'
+
+export interface SessionInfo {
+  port: number
+  context: string
+  project: string
+}
+
+function isSessionInfo(data: unknown): data is SessionInfo {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'port' in data &&
+    'context' in data &&
+    'project' in data &&
+    typeof (data as Record<string, unknown>).port === 'number' &&
+    typeof (data as Record<string, unknown>).context === 'string' &&
+    typeof (data as Record<string, unknown>).project === 'string'
+  )
+}
+
+export function parseLockFile(lockPath: string): SessionInfo | null {
+  try {
+    if (!fs.existsSync(lockPath)) {
+      return null
+    }
+
+    const content = fs.readFileSync(lockPath, 'utf8')
+    const data: unknown = JSON.parse(content)
+
+    if (!isSessionInfo(data)) {
+      return null
+    }
+
+    return {
+      port: data.port,
+      context: data.context,
+      project: data.project,
+    }
+  } catch (error) {
+    return null
+  }
+}
+
+export function listSessions(lockDir: string = '/tmp'): SessionInfo[] {
+  try {
+    if (!fs.existsSync(lockDir)) {
+      return []
+    }
+
+    const files = fs.readdirSync(lockDir)
+    const lockFiles = files.filter((file) => file.startsWith('claude-') && file.endsWith('.lock'))
+
+    const sessions: SessionInfo[] = []
+    for (const lockFile of lockFiles) {
+      const lockPath = path.join(lockDir, lockFile)
+      const sessionInfo = parseLockFile(lockPath)
+      if (sessionInfo) {
+        sessions.push(sessionInfo)
+      }
+    }
+
+    return sessions
+  } catch (error) {
+    return []
+  }
+}


### PR DESCRIPTION
## 概要
Implement the first step of claude-term project: discovering running Claude Code MCP servers through `.lock` files parsing.

## 変更内容
- [x] 機能追加

## 関連するIssue
Closes #2

## テスト
- [x] APIテスト (`npm test`) 通過

## 実装内容
### Core Implementation ✅ **完了** (2025-08-12)
- **SessionInfo interface**: Type-safe structure for session data (port, context, project)
- **parseLockFile()**: Parses individual lock files with proper JSON validation
- **listSessions()**: Scans configurable directory for claude-*.lock files
- **CLI command**: `claude-term sessions --lock-dir <path>` for listing sessions

### Test Coverage ✅ **完了** (2025-08-12)
- Unit tests for SessionInfo type validation
- Lock file parsing tests with error handling
- Session discovery functionality tests  
- CLI command integration tests
- All tests follow TDD Red-Green-Refactor approach

### Code Quality ✅ **完了** (2025-08-12)
- Type-safe JSON parsing with user-defined type guards
- Comprehensive error handling for malformed files
- ESLint and Prettier compliance
- ES modules compatibility

## Acceptance Criteria Met
- ✅ `listSessions()` returns correct structured data
- ✅ `claude-term sessions` prints clean, parseable list
- ✅ Configurable lock directory path (defaults to /tmp)
- ✅ Proper error handling for malformed lock file entries
- ✅ Unit tests with mock lock files under temp directory

## 関連ファイル
- `src/session-discovery.ts` - Core session discovery logic
- `src/session-discovery.test.ts` - Session discovery tests
- `src/cli.ts` - CLI command implementation  
- `src/cli.test.ts` - CLI integration tests